### PR TITLE
Improve formatting

### DIFF
--- a/outputFormatter.js
+++ b/outputFormatter.js
@@ -1,11 +1,64 @@
-export function formatOutput(file, format) {
+function formatXml(files) {
+  if (files.length === 1) {
+    const file = files[0];
+    return [
+      "<file>",
+      `  <path>${file.path}</path>`,
+      "  <content><![CDATA[",
+      file.content,
+      "  ]]></content>",
+      "</file>",
+    ].join("\n");
+  }
+
+  let output = "<files>\n";
+  for (const file of files) {
+    output += [
+      "  <file>",
+      `    <path>${file.path}</path>`,
+      "    <content><![CDATA[",
+      file.content,
+      "    ]]></content>",
+      "  </file>\n",
+    ].join("\n");
+  }
+  output += "</files>\n";
+  output += "<file_list>\n";
+  output += files.map((file) => file.path).join("\n");
+  output += "\n</file_list>";
+  return output;
+}
+
+function formatJson(files) {
+  if (files.length === 1) {
+    return JSON.stringify(files[0]);
+  }
+  return JSON.stringify({
+    files: files.map((file) => ({ path: file.path, content: file.content })),
+    file_list: files.map((file) => file.path),
+  });
+}
+
+function formatCodeblocks(files) {
+  let output = "";
+  for (const file of files) {
+    output += `File: ${file.path}\n\`\`\`\n${file.content}\n\`\`\`\n\n`;
+  }
+  if (files.length > 1) {
+    output += "File list:\n";
+    output += files.map((file) => file.path).join("\n");
+  }
+  return output;
+}
+
+export function formatOutput(files, format) {
   switch (format) {
     case "xml":
-      return `<file: ${file.path}>${file.content}\n</file: ${file.path}>`;
+      return formatXml(files);
     case "json":
-      return JSON.stringify({ path: file.path, content: file.content });
+      return formatJson(files);
     case "codeblocks":
-      return `File: ${file.path}\n\`\`\`\n${file.content}\n\`\`\``;
+      return formatCodeblocks(files);
     default:
       throw new Error(`Unsupported format: ${format}`);
   }


### PR DESCRIPTION
Before moving this project to public I tried changing up the xml format to make more sense in my head. Turned out I went further away from standard xml format and started noticing degraded responses to cnotext I was providing. I decided to work towards making the xml as optimal as possible. 

This is what it looked like originally (this morning):
```
<file>
<path>
file_path.js
</path>
<content>
lots of content here from the file
</content>
</file>
<file>
<path>
another_file.js
</path>
<content>
lots of content here from the second file
</content>
</file>
```

There was no root object and I suspect that will help if I pass in a lot of files plus I sometimes would need to reference a list of file names when I got to longer conversations or more context so I added a little file list section to hopefully steer the LLM to relevant context faster. 

This is what it now looks like:

```
<files>
  <file>
    <path>tokenizer.js</path>
    <content><![CDATA[
import { AutoTokenizer } from "@xenova/transformers";
...
    ]]></content>
  </file>
  <file>
    <path>outputFormatter.js</path>
    <content><![CDATA[
function formatXml(files) {
...
    ]]></content>
  </file>
</files>
<file_list>
tokenizer.js
outputFormatter.js
</file_list>
```

I am not positive if the CDATA stuff will be a pain or not but I think it should be useful. I'll observe performance over the next couple days. 

I also added in some printing so you can see the impact of the format you're deciding to use on the total token count!
![Screenshot_20240813_215230](https://github.com/user-attachments/assets/2809da2f-81e9-4971-82c2-928fba2f3826)
![Screenshot_20240813_215135](https://github.com/user-attachments/assets/9b0961de-0d63-4768-a97d-28af9f7678bc)

As you can see XML isn't too much overhead. On a larger project, I got the following result, which again feels really reasonable, especially because I think the file list will be impactful on things of this size. 
```
257899 tokens total, including 2612 from xml formatting.
```
