### PR TITLE
Fix intermittent clipboard copy failure

### DIFF
--- a/app.js
+++ b/app.js
@@ -196,7 +196,7 @@ async function main() {
     );
 
     // Copy formatted output to clipboard
-    await clipboardy.write(formattedOutput);
+    clipboardy.writeSync(formattedOutput);
     console.log("Formatted output has been copied to the clipboard.");
   } catch (error) {
     console.error("An error occurred:", error.message);

--- a/fileProcessor.js
+++ b/fileProcessor.js
@@ -13,6 +13,7 @@ const DEFAULT_IGNORE_PATTERNS = [
   ".gitattributes",
   ".gitmodules",
   "node_modules",
+  "LICENSE",
 ];
 
 function isTextFile(filePath) {


### PR DESCRIPTION
I had a bug where sometimes I'd not get the clipboard content to copy to my clipboard on execution. I thought about why it might be happening and realized the process may be exiting too quickly. I added a 1 second sleep after the async clipboard and I started getting successful copies every time. The sync clipboard copy command I think is a little better solution than either a sleep or a promise timeout and it doesn't seem to slow things down too much. I am also still successfully using this every time. I'll merge this later today if I experience no more probelms. 